### PR TITLE
Fix README.md config section to match json file

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,11 +78,12 @@ Must be a valid JSON
 ```javascript
 {
     "port": 5678,
+    "hostName": null,
     "registryFile": "./bowerRepository.json",
     "timeout": 144000,
     "public": {
         "disabled": false,
-        "registry": "http://bower.herokuapp.com/packages/",
+        "registry": "http://bower.herokuapp.com/packages",
         "registryFile": "./bowerRepositoryPublic.json",
         "whitelist": [],
         "blacklist": []
@@ -99,8 +100,12 @@ Must be a valid JSON
             "host": "localhost",
             "port": 6789,
             "protocol": "git",
-            "publicAccessURL" : null,
-            "refreshTimeout": 10
+            "publicAccessURL": null,
+            "refreshTimeout": 10,
+            "parameters": {
+                "timeout": 60000,
+                "max-connections": 100
+            }
         },
         "svn": {
             "enabled": false,
@@ -108,7 +113,7 @@ Must be a valid JSON
             "host": "localhost",
             "port": 7891,
             "protocol": "svn",
-            "publicAccessURL" : null,
+            "publicAccessURL": null,
             "refreshTimeout": 10
         }
     },


### PR DESCRIPTION
If you copy the config file from README.md, you won't get private-bower to work.
Public.registry url should not end with '/', otherwise, you will get the 'Cannot GET /packages/' cached for public packages.

I would suggest documentation to follow default config file.